### PR TITLE
Add OBI Energy custom Home Assistant integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,166 @@
-# obi_energy
+# OBI Energy for Home Assistant
+
+A custom Home Assistant integration for the OBI / heyOBI Energy Tracking
+system. It logs into the OBI backend, discovers your energy-tracking
+bridge/sensor, and exposes native Home Assistant entities — no YAML REST
+sensors required.
+
+> **Not an official OBI product.** This integration is community-built and
+> is not affiliated with, endorsed by, or supported by OBI or heyOBI. Use at
+> your own risk; the upstream API is undocumented and may change at any
+> time.
+
+## What is read out?
+
+Every scan interval, the integration fetches:
+
+- Bridge/sensor status via `GET /bridges` (online state, battery level,
+  connection strength, last record timestamp, upload interval, firmware and
+  hardware version).
+- Historical meter measurements via `GET /historical-data/{hh_id}/{mid_id}/meter`
+  for the `energy` and `negative_energy` measures.
+
+### `energy` vs. `negative_energy`
+
+- **`energy`** is the cumulative energy **consumed/drawn** from the grid
+  ("Strombezug"), in Wh.
+- **`negative_energy`** is the cumulative energy **fed back into the grid**
+  ("Einspeisung"), e.g. from solar production, in Wh.
+
+Both values are cumulative counters, similar to a physical meter — they only
+ever increase (until a meter reset). That's why the corresponding sensors
+use `state_class: total_increasing`.
+
+### Wh vs. kWh
+
+The OBI API reports values in **Wh**. This integration exposes both the raw
+Wh sensors and derived **kWh** sensors (value ÷ 1000) since most Home
+Assistant energy tooling — and the Energy Dashboard — expects kWh.
+
+## Created entities
+
+| Entity | Unit | Device class | State class |
+|---|---|---|---|
+| `sensor.obi_energy` | Wh | energy | total_increasing |
+| `sensor.obi_energy_kwh` | kWh | energy | total_increasing |
+| `sensor.obi_negative_energy` | Wh | energy | total_increasing |
+| `sensor.obi_einspeisung_kwh` | kWh | energy | total_increasing |
+| `sensor.obi_netto_energy_kwh` | kWh | energy | total (can be negative) |
+| `sensor.obi_bridge_battery` | % | battery | – |
+| `binary_sensor.obi_bridge_online` | – | connectivity | – |
+| `sensor.obi_bridge_connection_strength` | – | – | – (text, e.g. `GOOD_CONNECTION`) |
+| `sensor.obi_last_record_received` | – | timestamp | – |
+
+The connection-strength sensor also carries diagnostic attributes: `hh_id`,
+`mid_id`, `upload_interval`, `firmware_version`, `hardware_version`. A full
+diagnostics dump is also available via **Settings → Devices & Services →
+OBI Energy → Download diagnostics**.
+
+If the API returns no data for a measurement (e.g. during a temporary
+outage), the corresponding entity becomes **unavailable** rather than
+reporting `0`, so your Energy Dashboard statistics stay accurate.
+
+## Installation
+
+### HACS (custom repository)
+
+1. In HACS, add this repository as a custom repository (category:
+   Integration).
+2. Install "OBI Energy".
+3. Restart Home Assistant.
+
+### Manual
+
+1. Copy `custom_components/obi_energy` into your Home Assistant
+   `config/custom_components/` directory.
+2. Restart Home Assistant.
+
+## Setup (via the UI)
+
+No YAML configuration is needed or supported.
+
+1. Go to **Settings → Devices & Services → Add Integration** and search for
+   **OBI Energy**.
+2. Enter your OBI/heyOBI **email** and **password**. These are stored in
+   Home Assistant's encrypted config entry storage (not in
+   `secrets.yaml`, not in YAML at all) and are only used to obtain a
+   short-lived session token.
+3. The integration logs in and fetches your bridges:
+   - If exactly one bridge/sensor is found, it's used automatically.
+   - If multiple are found, you'll be asked to pick one.
+   - If the bridge list can't be retrieved, you can enter the household ID
+     (`HH_ID`) and sensor ID (`MID_ID`) manually.
+4. Entities appear automatically — no YAML required.
+
+### Options
+
+After setup, click **Configure** on the integration to adjust:
+
+- **Measurement scan interval** (default: 60 seconds)
+- **Login refresh interval** (default: 55 minutes) — how often the session
+  token is proactively renewed, independent of the 401-triggered refresh
+- **Historical data duration** (default: `PT6H`, ISO 8601 duration)
+- **Debug logging**
+- **Manual `HH_ID` / `MID_ID` overrides** (useful if `/bridges` starts
+  failing after setup)
+
+### Changing your password
+
+Use **Reconfigure** on the integration tile to update your OBI email or
+password. If OBI invalidates your session (e.g. after a password change),
+Home Assistant will automatically prompt a **Reauthentication** flow.
+
+## Energy Dashboard
+
+To use OBI Energy in the Home Assistant Energy Dashboard:
+
+1. Go to **Settings → Dashboards → Energy**.
+2. Under **Electricity grid → Add Consumption**, select
+   `sensor.obi_energy_kwh`.
+3. If you feed energy back into the grid (solar, etc.), under
+   **Return to grid**, select `sensor.obi_einspeisung_kwh`.
+
+Only the kWh, `total_increasing` sensors should be used in the Energy
+Dashboard — not the Wh sensors or the net sensor.
+
+## Token & credential handling
+
+- The JWT obtained at login is kept **only in memory** inside the
+  integration's API client. It is never stored on disk, never logged, and
+  never exposed as an entity, attribute, or diagnostic.
+- Your OBI password is never logged.
+- On a `401 Unauthorized` response, the integration automatically logs in
+  again and retries the request once.
+- The token is also proactively renewed before the configured login-refresh
+  interval elapses.
+
+## Troubleshooting
+
+### I get repeated login/auth failures (401)
+
+- Double-check your OBI email/password via **Reconfigure**.
+- If your OBI account password changed, Home Assistant should prompt a
+  **Reauthenticate** notification — follow it to enter the new password.
+- Persistent 401s after re-entering correct credentials usually mean OBI
+  has changed or rate-limited their login endpoint.
+
+### `/bridges` returns 404 or an empty list
+
+- This can happen if your account has no visible bridges yet, or the
+  endpoint is temporarily unavailable.
+- Use the **manual `HH_ID` / `MID_ID` override** in the integration options
+  to keep the integration running with known IDs.
+
+### Entities show "unavailable"
+
+This is expected when the API returns no data for that measurement (rather
+than showing a misleading `0`, which would corrupt Energy Dashboard
+statistics). Check Home Assistant logs (enable debug logging in the
+integration options) for the underlying cause once it recovers.
+
+## Security note
+
+Never post your JWT, email, or password in GitHub issues, logs, or
+screenshots when reporting problems. If you enable debug logging and share
+logs, review them first — credentials and tokens are deliberately excluded
+from all log output, but request/response bodies are not logged by design.

--- a/custom_components/obi_energy/__init__.py
+++ b/custom_components/obi_energy/__init__.py
@@ -1,0 +1,88 @@
+"""The OBI Energy integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_SCAN_INTERVAL, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import ObiApiClient
+from .const import (
+    CONF_DEBUG,
+    CONF_HH_ID,
+    CONF_HISTORICAL_DURATION,
+    CONF_LOGIN_REFRESH_INTERVAL,
+    CONF_MID_ID,
+    DEFAULT_DEBUG,
+    DEFAULT_HISTORICAL_DURATION,
+    DEFAULT_LOGIN_REFRESH_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+from .coordinator import ObiEnergyCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up OBI Energy from a config entry."""
+    options = entry.options
+
+    if options.get(CONF_DEBUG, DEFAULT_DEBUG):
+        logging.getLogger(__package__).setLevel(logging.DEBUG)
+    else:
+        logging.getLogger(__package__).setLevel(logging.NOTSET)
+
+    session = async_get_clientsession(hass)
+    login_refresh_interval = options.get(
+        CONF_LOGIN_REFRESH_INTERVAL, DEFAULT_LOGIN_REFRESH_INTERVAL
+    )
+    client = ObiApiClient(
+        session,
+        entry.data[CONF_EMAIL],
+        entry.data[CONF_PASSWORD],
+        login_refresh_interval,
+    )
+
+    hh_id = options.get(CONF_HH_ID) or entry.data[CONF_HH_ID]
+    mid_id = options.get(CONF_MID_ID) or entry.data[CONF_MID_ID]
+    scan_interval = options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    historical_duration = options.get(
+        CONF_HISTORICAL_DURATION, DEFAULT_HISTORICAL_DURATION
+    )
+
+    coordinator = ObiEnergyCoordinator(
+        hass,
+        entry,
+        client,
+        hh_id,
+        mid_id,
+        scan_interval,
+        historical_duration,
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    entry.async_on_unload(entry.add_update_listener(_async_update_listener))
+
+    return True
+
+
+async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+    return unload_ok

--- a/custom_components/obi_energy/api.py
+++ b/custom_components/obi_energy/api.py
@@ -1,0 +1,199 @@
+"""API client for the OBI / heyOBI Energy Tracking backend.
+
+The JWT obtained on login is only ever kept in memory on this client. It is
+never logged, never persisted, and never exposed to entities or attributes.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from aiohttp import ClientError, ClientResponseError, ClientSession
+from aiohttp.client_exceptions import ClientConnectorError
+
+from .const import (
+    ACCEPT_BRIDGES,
+    ACCEPT_HISTORICAL,
+    ACCEPT_LANGUAGE,
+    API_KEY,
+    BRIDGES_URL,
+    HISTORICAL_DATA_URL_TEMPLATE,
+    LOGIN_URL,
+    USER_AGENT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+_REQUEST_TIMEOUT = 30
+
+
+class ObiApiError(Exception):
+    """Base exception for OBI API errors."""
+
+
+class ObiAuthError(ObiApiError):
+    """Raised when authentication fails (bad credentials or expired session)."""
+
+
+class ObiConnectionError(ObiApiError):
+    """Raised on network or unexpected HTTP errors."""
+
+
+class ObiNotFoundError(ObiApiError):
+    """Raised when a resource (e.g. /bridges) returns 404."""
+
+
+class ObiApiClient:
+    """Thin async client for the OBI Energy Tracking API."""
+
+    def __init__(
+        self,
+        session: ClientSession,
+        email: str,
+        password: str,
+        login_refresh_interval: int,
+    ) -> None:
+        """Initialize the client. The token is kept only in memory."""
+        self._session = session
+        self._email = email
+        self._password = password
+        self._login_refresh_interval = timedelta(seconds=login_refresh_interval)
+        self._token: str | None = None
+        self._token_obtained_at: datetime | None = None
+
+    def update_credentials(self, email: str, password: str) -> None:
+        """Update the credentials used for future logins."""
+        self._email = email
+        self._password = password
+        self._token = None
+        self._token_obtained_at = None
+
+    def update_login_refresh_interval(self, login_refresh_interval: int) -> None:
+        """Update how often the token is proactively refreshed."""
+        self._login_refresh_interval = timedelta(seconds=login_refresh_interval)
+
+    @property
+    def is_authenticated(self) -> bool:
+        """Return whether a token is currently held in memory."""
+        return self._token is not None
+
+    def _token_is_stale(self) -> bool:
+        if self._token is None or self._token_obtained_at is None:
+            return True
+        return datetime.now(timezone.utc) - self._token_obtained_at >= self._login_refresh_interval
+
+    async def async_login(self) -> None:
+        """Log in to OBI and store the resulting JWT in memory only."""
+        headers = {
+            "content-type": "application/json",
+            "accept": "*/*",
+            "user-agent": USER_AGENT,
+            "accept-language": ACCEPT_LANGUAGE,
+            "accept-encoding": "identity",
+        }
+        try:
+            async with self._session.post(
+                LOGIN_URL,
+                json={"email": self._email, "password": self._password},
+                headers=headers,
+                timeout=_REQUEST_TIMEOUT,
+            ) as resp:
+                if resp.status in (401, 403):
+                    raise ObiAuthError("Login failed: invalid credentials")
+                resp.raise_for_status()
+                data = await resp.json(content_type=None)
+        except ClientResponseError as err:
+            if err.status in (401, 403):
+                raise ObiAuthError("Login failed: invalid credentials") from err
+            raise ObiConnectionError(
+                f"Login request failed with HTTP {err.status}"
+            ) from err
+        except ClientConnectorError as err:
+            raise ObiConnectionError("Could not connect to OBI login endpoint") from err
+        except ClientError as err:
+            raise ObiConnectionError("Network error during OBI login") from err
+        except ValueError as err:
+            # JSON decoding failed
+            raise ObiConnectionError("Received invalid response from OBI login") from err
+
+        token = data.get("token") if isinstance(data, dict) else None
+        if not token:
+            raise ObiAuthError("Login response did not contain a token")
+
+        self._token = token
+        self._token_obtained_at = datetime.now(timezone.utc)
+        _LOGGER.debug("OBI login succeeded")
+
+    def _api_headers(self, accept: str) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self._token}",
+            "x-api-key": API_KEY,
+            "x-app-type": "b2c",
+            "Accept": accept,
+            "accept-language": ACCEPT_LANGUAGE,
+            "user-agent": USER_AGENT,
+        }
+
+    async def _ensure_logged_in(self) -> None:
+        if self._token_is_stale():
+            await self.async_login()
+
+    async def _authenticated_get(
+        self, url: str, *, accept: str, params: dict[str, Any] | None = None
+    ) -> Any:
+        await self._ensure_logged_in()
+
+        for attempt in range(2):
+            headers = self._api_headers(accept)
+            try:
+                async with self._session.get(
+                    url, headers=headers, params=params, timeout=_REQUEST_TIMEOUT
+                ) as resp:
+                    if resp.status == 401:
+                        if attempt == 0:
+                            _LOGGER.debug(
+                                "OBI API returned 401, refreshing token and retrying"
+                            )
+                            await self.async_login()
+                            continue
+                        raise ObiAuthError("Not authorized after refreshing token")
+                    if resp.status == 404:
+                        raise ObiNotFoundError(f"Resource not found: {url}")
+                    resp.raise_for_status()
+                    return await resp.json(content_type=None)
+            except ClientResponseError as err:
+                raise ObiConnectionError(
+                    f"Request to {url} failed with HTTP {err.status}"
+                ) from err
+            except ClientConnectorError as err:
+                raise ObiConnectionError(f"Could not connect to {url}") from err
+            except ClientError as err:
+                raise ObiConnectionError(f"Network error requesting {url}") from err
+            except ValueError as err:
+                raise ObiConnectionError(f"Received invalid response from {url}") from err
+
+        raise ObiAuthError("Not authorized after refreshing token")
+
+    async def async_get_bridges(self) -> list[dict[str, Any]]:
+        """Return the list of bridges (households) with their sensors."""
+        data = await self._authenticated_get(BRIDGES_URL, accept=ACCEPT_BRIDGES)
+        if not isinstance(data, list):
+            raise ObiConnectionError("Unexpected response format for /bridges")
+        return data
+
+    async def async_get_historical_data(
+        self, hh_id: str, mid_id: str, duration: str
+    ) -> list[dict[str, Any]]:
+        """Return historical measurements for the given bridge/sensor."""
+        url = HISTORICAL_DATA_URL_TEMPLATE.format(hh_id=hh_id, mid_id=mid_id)
+        end = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        params = {
+            "end": end,
+            "duration": duration,
+            "measures": "energy,negative_energy",
+        }
+        data = await self._authenticated_get(url, accept=ACCEPT_HISTORICAL, params=params)
+        if not isinstance(data, list):
+            raise ObiConnectionError("Unexpected response format for historical data")
+        return data

--- a/custom_components/obi_energy/binary_sensor.py
+++ b/custom_components/obi_energy/binary_sensor.py
@@ -1,0 +1,67 @@
+"""Binary sensor platform for the OBI Energy integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ObiEnergyCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the OBI Energy binary sensor from a config entry."""
+    coordinator: ObiEnergyCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([ObiBridgeOnlineBinarySensor(coordinator, entry)])
+
+
+class ObiBridgeOnlineBinarySensor(
+    CoordinatorEntity[ObiEnergyCoordinator], BinarySensorEntity
+):
+    """Whether the OBI bridge sensor is currently online."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(coordinator)
+        self.entity_description = BinarySensorEntityDescription(
+            key="bridge_online",
+            name="OBI Bridge Online",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            entity_category=EntityCategory.DIAGNOSTIC,
+        )
+        self._attr_unique_id = f"{entry.entry_id}_bridge_online"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.hh_id}_{coordinator.mid_id}")},
+            name="OBI Energy Bridge",
+            manufacturer="OBI",
+            model="heyOBI Energy Tracking",
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if bridge/sensor info is known."""
+        return super().available and self.coordinator.data.sensor_info is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True if the bridge sensor reports itself as online."""
+        sensor_info = self.coordinator.data.sensor_info
+        return sensor_info.get("isOnline") if sensor_info else None

--- a/custom_components/obi_energy/config_flow.py
+++ b/custom_components/obi_energy/config_flow.py
@@ -1,0 +1,313 @@
+"""Config flow for the OBI Energy integration."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_SCAN_INTERVAL
+from homeassistant.core import callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import ObiApiClient, ObiAuthError, ObiConnectionError, ObiNotFoundError
+from .const import (
+    CONF_DEBUG,
+    CONF_HH_ID,
+    CONF_HISTORICAL_DURATION,
+    CONF_LOGIN_REFRESH_INTERVAL,
+    CONF_MID_ID,
+    DEFAULT_DEBUG,
+    DEFAULT_HISTORICAL_DURATION,
+    DEFAULT_LOGIN_REFRESH_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_EMAIL): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+STEP_MANUAL_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HH_ID): str,
+        vol.Required(CONF_MID_ID): str,
+    }
+)
+
+
+def _flatten_bridges(bridges: list[dict[str, Any]]) -> list[tuple[str, str, str]]:
+    """Flatten the /bridges response into (hh_id, mid_id, label) tuples."""
+    pairs: list[tuple[str, str, str]] = []
+    for bridge in bridges:
+        hh_id = bridge.get("id")
+        if not hh_id:
+            continue
+        for sensor in bridge.get("sensors", []):
+            mid_id = sensor.get("id")
+            if not mid_id:
+                continue
+            strength = sensor.get("connectionStrength", "")
+            battery = sensor.get("batteryLevel", "")
+            label = f"{hh_id} / {mid_id} ({strength}, {battery}%)"
+            pairs.append((hh_id, mid_id, label))
+    return pairs
+
+
+class ObiEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for OBI Energy."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self._email: str | None = None
+        self._password: str | None = None
+        self._client: ObiApiClient | None = None
+        self._pairs: list[tuple[str, str, str]] = []
+        self._reauth_entry: config_entries.ConfigEntry | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Handle the initial step: ask for OBI email and password."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            self._email = user_input[CONF_EMAIL]
+            self._password = user_input[CONF_PASSWORD]
+
+            session = async_get_clientsession(self.hass)
+            client = ObiApiClient(
+                session, self._email, self._password, DEFAULT_LOGIN_REFRESH_INTERVAL
+            )
+
+            try:
+                await client.async_login()
+            except ObiAuthError:
+                errors["base"] = "invalid_auth"
+            except ObiConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                self._client = client
+                try:
+                    bridges = await client.async_get_bridges()
+                except ObiNotFoundError:
+                    return await self.async_step_manual()
+                except ObiConnectionError:
+                    errors["base"] = "cannot_connect"
+                else:
+                    pairs = _flatten_bridges(bridges)
+                    if not pairs:
+                        return await self.async_step_manual()
+                    if len(pairs) == 1:
+                        hh_id, mid_id, _label = pairs[0]
+                        return await self._async_create_entry(hh_id, mid_id)
+                    self._pairs = pairs
+                    return await self.async_step_select_bridge()
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_select_bridge(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Let the user pick a bridge/sensor when multiple are found."""
+        errors: dict[str, str] = {}
+        choices = {f"{hh_id}|{mid_id}": label for hh_id, mid_id, label in self._pairs}
+
+        if user_input is not None:
+            hh_id, mid_id = user_input["bridge"].split("|", 1)
+            return await self._async_create_entry(hh_id, mid_id)
+
+        schema = vol.Schema({vol.Required("bridge"): vol.In(choices)})
+        return self.async_show_form(
+            step_id="select_bridge", data_schema=schema, errors=errors
+        )
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Ask for HH_ID/MID_ID manually when /bridges is unavailable or empty."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            hh_id = user_input[CONF_HH_ID]
+            mid_id = user_input[CONF_MID_ID]
+
+            try:
+                await self._client.async_get_historical_data(
+                    hh_id, mid_id, DEFAULT_HISTORICAL_DURATION
+                )
+            except ObiNotFoundError:
+                errors["base"] = "invalid_ids"
+            except ObiConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return await self._async_create_entry(hh_id, mid_id)
+
+        return self.async_show_form(
+            step_id="manual", data_schema=STEP_MANUAL_DATA_SCHEMA, errors=errors
+        )
+
+    async def _async_create_entry(
+        self, hh_id: str, mid_id: str
+    ) -> config_entries.ConfigFlowResult:
+        """Create the config entry once email/password/hh_id/mid_id are known."""
+        await self.async_set_unique_id(f"{hh_id}_{mid_id}")
+        self._abort_if_unique_id_configured()
+
+        data = {
+            CONF_EMAIL: self._email,
+            CONF_PASSWORD: self._password,
+            CONF_HH_ID: hh_id,
+            CONF_MID_ID: mid_id,
+        }
+        return self.async_create_entry(title="OBI Energy", data=data)
+
+    async def async_step_reauth(
+        self, entry_data: dict[str, Any]
+    ) -> config_entries.ConfigFlowResult:
+        """Handle reauthentication triggered by ConfigEntryAuthFailed."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        self._email = entry_data.get(CONF_EMAIL)
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Ask for a new password and verify it before updating the entry."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None and self._reauth_entry is not None:
+            password = user_input[CONF_PASSWORD]
+            session = async_get_clientsession(self.hass)
+            client = ObiApiClient(
+                session, self._email, password, DEFAULT_LOGIN_REFRESH_INTERVAL
+            )
+            try:
+                await client.async_login()
+            except ObiAuthError:
+                errors["base"] = "invalid_auth"
+            except ObiConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                new_data = {**self._reauth_entry.data, CONF_PASSWORD: password}
+                self.hass.config_entries.async_update_entry(
+                    self._reauth_entry, data=new_data
+                )
+                await self.hass.config_entries.async_reload(
+                    self._reauth_entry.entry_id
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        schema = vol.Schema({vol.Required(CONF_PASSWORD): str})
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=schema,
+            errors=errors,
+            description_placeholders={"email": self._email or ""},
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Allow changing OBI email/password from an existing entry."""
+        return await self.async_step_reconfigure_confirm(user_input)
+
+    async def async_step_reconfigure_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Verify and store new credentials for an existing entry."""
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        errors: dict[str, str] = {}
+
+        if user_input is not None and entry is not None:
+            email = user_input[CONF_EMAIL]
+            password = user_input[CONF_PASSWORD]
+            session = async_get_clientsession(self.hass)
+            client = ObiApiClient(
+                session, email, password, DEFAULT_LOGIN_REFRESH_INTERVAL
+            )
+            try:
+                await client.async_login()
+            except ObiAuthError:
+                errors["base"] = "invalid_auth"
+            except ObiConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                new_data = {**entry.data, CONF_EMAIL: email, CONF_PASSWORD: password}
+                self.hass.config_entries.async_update_entry(entry, data=new_data)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reconfigure_successful")
+
+        default_email = entry.data.get(CONF_EMAIL, "") if entry is not None else ""
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_EMAIL, default=default_email): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+        return self.async_show_form(
+            step_id="reconfigure_confirm", data_schema=schema, errors=errors
+        )
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> ObiEnergyOptionsFlow:
+        """Create the options flow."""
+        return ObiEnergyOptionsFlow()
+
+
+class ObiEnergyOptionsFlow(config_entries.OptionsFlow):
+    """Handle OBI Energy options: scan interval, refresh, duration, debug, manual IDs."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        options = self.config_entry.options
+        data = self.config_entry.data
+        schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL),
+                ): vol.All(vol.Coerce(int), vol.Range(min=10)),
+                vol.Required(
+                    CONF_LOGIN_REFRESH_INTERVAL,
+                    default=options.get(
+                        CONF_LOGIN_REFRESH_INTERVAL, DEFAULT_LOGIN_REFRESH_INTERVAL
+                    ),
+                ): vol.All(vol.Coerce(int), vol.Range(min=60)),
+                vol.Required(
+                    CONF_HISTORICAL_DURATION,
+                    default=options.get(
+                        CONF_HISTORICAL_DURATION, DEFAULT_HISTORICAL_DURATION
+                    ),
+                ): str,
+                vol.Required(
+                    CONF_DEBUG, default=options.get(CONF_DEBUG, DEFAULT_DEBUG)
+                ): bool,
+                vol.Optional(
+                    CONF_HH_ID,
+                    default=options.get(CONF_HH_ID, data.get(CONF_HH_ID, "")),
+                ): str,
+                vol.Optional(
+                    CONF_MID_ID,
+                    default=options.get(CONF_MID_ID, data.get(CONF_MID_ID, "")),
+                ): str,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/obi_energy/const.py
+++ b/custom_components/obi_energy/const.py
@@ -1,0 +1,34 @@
+"""Constants for the OBI Energy integration."""
+from __future__ import annotations
+
+DOMAIN = "obi_energy"
+
+# Config entry / options keys
+CONF_HH_ID = "hh_id"
+CONF_MID_ID = "mid_id"
+CONF_HISTORICAL_DURATION = "historical_duration"
+CONF_LOGIN_REFRESH_INTERVAL = "login_refresh_interval"
+CONF_DEBUG = "debug"
+
+# Defaults
+DEFAULT_SCAN_INTERVAL = 60  # seconds
+DEFAULT_LOGIN_REFRESH_INTERVAL = 55 * 60  # seconds
+DEFAULT_HISTORICAL_DURATION = "PT6H"
+DEFAULT_DEBUG = False
+
+# API
+LOGIN_URL = "https://www.obi.de/regi/auth/api/public/login"
+API_BASE_URL = "https://energy-tracking-backend.prod-eks.dbs.obi.solutions"
+BRIDGES_URL = f"{API_BASE_URL}/bridges"
+HISTORICAL_DATA_URL_TEMPLATE = API_BASE_URL + "/historical-data/{hh_id}/{mid_id}/meter"
+
+API_KEY = "Rh57q3vtOPYTf6FtArVN1boy2AyEiIqaGEmnMks7"
+USER_AGENT = "heyOBI APP / iPhone17,2 / 4.9.1 / 560"
+ACCEPT_LANGUAGE = "de-DE,de;q=0.9"
+ACCEPT_BRIDGES = "application/vnd.obi.companion.energy-tracking.bridge.v1+json"
+ACCEPT_HISTORICAL = "application/vnd.obi.companion.energy-tracking.historical-record.v1+json"
+
+MEASURE_ENERGY = "energy"
+MEASURE_NEGATIVE_ENERGY = "negative_energy"
+
+WH_PER_KWH = 1000

--- a/custom_components/obi_energy/coordinator.py
+++ b/custom_components/obi_energy/coordinator.py
@@ -1,0 +1,110 @@
+"""DataUpdateCoordinator for the OBI Energy integration."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import ObiApiClient, ObiApiError, ObiAuthError, ObiNotFoundError
+from .const import DOMAIN, MEASURE_ENERGY, MEASURE_NEGATIVE_ENERGY
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class ObiEnergyData:
+    """Snapshot of the latest data fetched from the OBI API."""
+
+    sensor_info: dict[str, Any] | None
+    energy: dict[str, Any] | None
+    negative_energy: dict[str, Any] | None
+    bridges_available: bool
+
+
+def _latest_measurement(
+    records: list[dict[str, Any]], measure: str
+) -> dict[str, Any] | None:
+    """Return the most recent record for the given measure, if any."""
+    matching = [
+        record
+        for record in records
+        if record.get("measure") == measure and record.get("value") is not None
+    ]
+    if not matching:
+        return None
+    return max(matching, key=lambda record: record.get("timestamp") or "")
+
+
+class ObiEnergyCoordinator(DataUpdateCoordinator[ObiEnergyData]):
+    """Coordinator that polls the OBI API for bridge status and measurements."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        client: ObiApiClient,
+        hh_id: str,
+        mid_id: str,
+        update_interval: int,
+        historical_duration: str,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            config_entry=entry,
+            update_interval=timedelta(seconds=update_interval),
+        )
+        self.client = client
+        self.hh_id = hh_id
+        self.mid_id = mid_id
+        self.historical_duration = historical_duration
+
+    async def _async_update_data(self) -> ObiEnergyData:
+        """Fetch the latest bridge status and historical measurements."""
+        sensor_info: dict[str, Any] | None = None
+        bridges_available = True
+
+        try:
+            bridges = await self.client.async_get_bridges()
+        except ObiAuthError as err:
+            raise ConfigEntryAuthFailed("OBI authentication failed") from err
+        except ObiNotFoundError:
+            bridges_available = False
+            bridges = []
+        except ObiApiError as err:
+            raise UpdateFailed(str(err)) from err
+
+        for bridge in bridges:
+            if bridge.get("id") != self.hh_id:
+                continue
+            for sensor in bridge.get("sensors", []):
+                if sensor.get("id") == self.mid_id:
+                    sensor_info = sensor
+                    break
+
+        try:
+            historical = await self.client.async_get_historical_data(
+                self.hh_id, self.mid_id, self.historical_duration
+            )
+        except ObiAuthError as err:
+            raise ConfigEntryAuthFailed("OBI authentication failed") from err
+        except ObiApiError as err:
+            raise UpdateFailed(str(err)) from err
+
+        energy = _latest_measurement(historical, MEASURE_ENERGY)
+        negative_energy = _latest_measurement(historical, MEASURE_NEGATIVE_ENERGY)
+
+        return ObiEnergyData(
+            sensor_info=sensor_info,
+            energy=energy,
+            negative_energy=negative_energy,
+            bridges_available=bridges_available,
+        )

--- a/custom_components/obi_energy/diagnostics.py
+++ b/custom_components/obi_energy/diagnostics.py
@@ -1,0 +1,49 @@
+"""Diagnostics support for the OBI Energy integration.
+
+The OBI email, password and JWT are never exposed here. The API client only
+ever keeps the token in memory and does not expose it to diagnostics.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .coordinator import ObiEnergyCoordinator
+
+TO_REDACT = {CONF_EMAIL, CONF_PASSWORD}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator: ObiEnergyCoordinator = hass.data[DOMAIN][entry.entry_id]
+    data = coordinator.data
+    sensor_info = data.sensor_info if data else None
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "entry_options": dict(entry.options),
+        "hh_id": coordinator.hh_id,
+        "mid_id": coordinator.mid_id,
+        "historical_duration": coordinator.historical_duration,
+        "last_update_success": coordinator.last_update_success,
+        "bridge_reachable": data.bridges_available if data else None,
+        "sensor_info": {
+            "uploadInterval": sensor_info.get("uploadInterval") if sensor_info else None,
+            "firmwareVersion": sensor_info.get("firmwareVersion") if sensor_info else None,
+            "hardwareVersion": sensor_info.get("hardwareVersion") if sensor_info else None,
+            "connectionStrength": sensor_info.get("connectionStrength")
+            if sensor_info
+            else None,
+            "batteryLevel": sensor_info.get("batteryLevel") if sensor_info else None,
+            "isOnline": sensor_info.get("isOnline") if sensor_info else None,
+        },
+        "energy": data.energy if data else None,
+        "negative_energy": data.negative_energy if data else None,
+    }

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "obi_energy",
+  "name": "OBI Energy",
+  "codeowners": ["@karo-x"],
+  "config_flow": true,
+  "documentation": "https://github.com/karo-x/obi_energy",
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "issue_tracker": "https://github.com/karo-x/obi_energy/issues",
+  "requirements": [],
+  "version": "1.0.0"
+}

--- a/custom_components/obi_energy/sensor.py
+++ b/custom_components/obi_energy/sensor.py
@@ -1,0 +1,334 @@
+"""Sensor platform for the OBI Energy integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE, UnitOfEnergy
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN, WH_PER_KWH
+from .coordinator import ObiEnergyCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up OBI Energy sensors from a config entry."""
+    coordinator: ObiEnergyCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        [
+            ObiEnergySensor(coordinator, entry),
+            ObiEnergyKwhSensor(coordinator, entry),
+            ObiNegativeEnergySensor(coordinator, entry),
+            ObiEinspeisungKwhSensor(coordinator, entry),
+            ObiNettoEnergyKwhSensor(coordinator, entry),
+            ObiBridgeBatterySensor(coordinator, entry),
+            ObiBridgeConnectionStrengthSensor(coordinator, entry),
+            ObiLastRecordReceivedSensor(coordinator, entry),
+        ]
+    )
+
+
+class ObiEnergyBaseEntity(CoordinatorEntity[ObiEnergyCoordinator], SensorEntity):
+    """Common base for all OBI Energy sensors."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: ObiEnergyCoordinator,
+        entry: ConfigEntry,
+        description: SensorEntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.hh_id}_{coordinator.mid_id}")},
+            name="OBI Energy Bridge",
+            manufacturer="OBI",
+            model="heyOBI Energy Tracking",
+        )
+
+
+class ObiEnergySensor(ObiEnergyBaseEntity):
+    """Cumulative energy consumption in Wh."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="energy",
+                name="OBI Energy",
+                native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL_INCREASING,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the last energy measurement is known."""
+        return super().available and self.coordinator.data.energy is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the latest cumulative energy value in Wh."""
+        energy = self.coordinator.data.energy
+        return energy["value"] if energy else None
+
+
+class ObiEnergyKwhSensor(ObiEnergyBaseEntity):
+    """Cumulative energy consumption in kWh."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="energy_kwh",
+                name="OBI Energy kWh",
+                native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL_INCREASING,
+                suggested_display_precision=2,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the last energy measurement is known."""
+        return super().available and self.coordinator.data.energy is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the latest cumulative energy value in kWh."""
+        energy = self.coordinator.data.energy
+        return energy["value"] / WH_PER_KWH if energy else None
+
+
+class ObiNegativeEnergySensor(ObiEnergyBaseEntity):
+    """Cumulative feed-in (negative energy) in Wh."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="negative_energy",
+                name="OBI Negative Energy",
+                native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL_INCREASING,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the last feed-in measurement is known."""
+        return super().available and self.coordinator.data.negative_energy is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the latest cumulative feed-in value in Wh."""
+        negative_energy = self.coordinator.data.negative_energy
+        return negative_energy["value"] if negative_energy else None
+
+
+class ObiEinspeisungKwhSensor(ObiEnergyBaseEntity):
+    """Cumulative feed-in (Einspeisung) in kWh."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="einspeisung_kwh",
+                name="OBI Einspeisung kWh",
+                native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL_INCREASING,
+                suggested_display_precision=2,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if the last feed-in measurement is known."""
+        return super().available and self.coordinator.data.negative_energy is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the latest cumulative feed-in value in kWh."""
+        negative_energy = self.coordinator.data.negative_energy
+        return negative_energy["value"] / WH_PER_KWH if negative_energy else None
+
+
+class ObiNettoEnergyKwhSensor(ObiEnergyBaseEntity):
+    """Net energy (consumption minus feed-in) in kWh. Can be negative."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="netto_energy_kwh",
+                name="OBI Netto Energy kWh",
+                native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                device_class=SensorDeviceClass.ENERGY,
+                state_class=SensorStateClass.TOTAL,
+                suggested_display_precision=2,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True only when both measurements are known."""
+        data = self.coordinator.data
+        return (
+            super().available
+            and data.energy is not None
+            and data.negative_energy is not None
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return consumption minus feed-in, in kWh."""
+        data = self.coordinator.data
+        if data.energy is None or data.negative_energy is None:
+            return None
+        return (data.energy["value"] - data.negative_energy["value"]) / WH_PER_KWH
+
+
+class ObiBridgeBatterySensor(ObiEnergyBaseEntity):
+    """Battery level of the OBI bridge sensor."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="bridge_battery",
+                name="OBI Bridge Battery",
+                native_unit_of_measurement=PERCENTAGE,
+                device_class=SensorDeviceClass.BATTERY,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if bridge/sensor info is known."""
+        return super().available and self.coordinator.data.sensor_info is not None
+
+    @property
+    def native_value(self) -> int | None:
+        """Return the battery level percentage."""
+        sensor_info = self.coordinator.data.sensor_info
+        return sensor_info.get("batteryLevel") if sensor_info else None
+
+
+class ObiBridgeConnectionStrengthSensor(ObiEnergyBaseEntity):
+    """Textual connection strength of the OBI bridge sensor."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="bridge_connection_strength",
+                name="OBI Bridge Connection Strength",
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if bridge/sensor info is known."""
+        return super().available and self.coordinator.data.sensor_info is not None
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the connection strength, e.g. GOOD_CONNECTION."""
+        sensor_info = self.coordinator.data.sensor_info
+        return sensor_info.get("connectionStrength") if sensor_info else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose non-sensitive diagnostic identifiers as attributes.
+
+        Never includes the JWT or credentials.
+        """
+        sensor_info = self.coordinator.data.sensor_info or {}
+        return {
+            "hh_id": self.coordinator.hh_id,
+            "mid_id": self.coordinator.mid_id,
+            "upload_interval": sensor_info.get("uploadInterval"),
+            "firmware_version": sensor_info.get("firmwareVersion"),
+            "hardware_version": sensor_info.get("hardwareVersion"),
+        }
+
+
+class ObiLastRecordReceivedSensor(ObiEnergyBaseEntity):
+    """Timestamp of the last record received from the bridge sensor."""
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            entry,
+            SensorEntityDescription(
+                key="last_record_received",
+                name="OBI Last Record Received",
+                device_class=SensorDeviceClass.TIMESTAMP,
+                entity_category=EntityCategory.DIAGNOSTIC,
+            ),
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return True if a last-received timestamp is known."""
+        sensor_info = self.coordinator.data.sensor_info
+        return (
+            super().available
+            and sensor_info is not None
+            and sensor_info.get("lastRecordReceivedAt") is not None
+        )
+
+    @property
+    def native_value(self):
+        """Return the last-received timestamp as a datetime."""
+        sensor_info = self.coordinator.data.sensor_info
+        if not sensor_info:
+            return None
+        raw = sensor_info.get("lastRecordReceivedAt")
+        if not raw:
+            return None
+        return dt_util.parse_datetime(raw)

--- a/custom_components/obi_energy/strings.json
+++ b/custom_components/obi_energy/strings.json
@@ -1,0 +1,70 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to OBI Energy",
+        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token.",
+        "data": {
+          "email": "OBI email",
+          "password": "OBI password"
+        }
+      },
+      "select_bridge": {
+        "title": "Select bridge and sensor",
+        "description": "Multiple OBI bridges/sensors were found on your account. Choose the one to monitor.",
+        "data": {
+          "bridge": "Bridge / sensor"
+        }
+      },
+      "manual": {
+        "title": "Enter bridge and sensor IDs manually",
+        "description": "The bridge list could not be retrieved automatically. Enter the household ID (HH_ID) and sensor ID (MID_ID) manually.",
+        "data": {
+          "hh_id": "Household ID (HH_ID)",
+          "mid_id": "Sensor ID (MID_ID)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with OBI",
+        "description": "The stored OBI password for {email} no longer works. Enter the current password to continue.",
+        "data": {
+          "password": "OBI password"
+        }
+      },
+      "reconfigure_confirm": {
+        "title": "Update OBI credentials",
+        "description": "Update the OBI email and/or password used by this integration.",
+        "data": {
+          "email": "OBI email",
+          "password": "OBI password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Login failed. Please check your OBI email and password.",
+      "cannot_connect": "Could not connect to the OBI servers. Please try again later.",
+      "invalid_ids": "No data could be found for the entered household/sensor ID."
+    },
+    "abort": {
+      "already_configured": "This bridge/sensor is already configured.",
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "The OBI credentials were updated successfully."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "OBI Energy options",
+        "description": "Configure how often data is fetched and refreshed.",
+        "data": {
+          "scan_interval": "Measurement scan interval (seconds)",
+          "login_refresh_interval": "Login refresh interval (seconds)",
+          "historical_duration": "Historical data duration (ISO 8601, e.g. PT6H)",
+          "debug": "Enable debug logging",
+          "hh_id": "Override household ID (HH_ID)",
+          "mid_id": "Override sensor ID (MID_ID)"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/obi_energy/translations/de.json
+++ b/custom_components/obi_energy/translations/de.json
@@ -1,0 +1,70 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Mit OBI Energy verbinden",
+        "description": "Gib die E-Mail-Adresse und das Passwort ein, die du auch für die heyOBI-App verwendest. Deine Zugangsdaten werden sicher im Config Entry von Home Assistant gespeichert, niemals in YAML, und nur verwendet, um ein Sitzungs-Token zu erhalten.",
+        "data": {
+          "email": "OBI E-Mail",
+          "password": "OBI Passwort"
+        }
+      },
+      "select_bridge": {
+        "title": "Bridge und Sensor auswählen",
+        "description": "Es wurden mehrere OBI-Bridges/Sensoren in deinem Konto gefunden. Wähle den aus, der überwacht werden soll.",
+        "data": {
+          "bridge": "Bridge / Sensor"
+        }
+      },
+      "manual": {
+        "title": "Bridge- und Sensor-ID manuell eingeben",
+        "description": "Die Bridge-Liste konnte nicht automatisch abgerufen werden. Gib die Haushalts-ID (HH_ID) und die Sensor-ID (MID_ID) manuell ein.",
+        "data": {
+          "hh_id": "Haushalts-ID (HH_ID)",
+          "mid_id": "Sensor-ID (MID_ID)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Erneut bei OBI anmelden",
+        "description": "Das gespeicherte OBI-Passwort für {email} funktioniert nicht mehr. Gib das aktuelle Passwort ein, um fortzufahren.",
+        "data": {
+          "password": "OBI Passwort"
+        }
+      },
+      "reconfigure_confirm": {
+        "title": "OBI-Zugangsdaten aktualisieren",
+        "description": "Aktualisiere die von dieser Integration verwendete OBI E-Mail und/oder das Passwort.",
+        "data": {
+          "email": "OBI E-Mail",
+          "password": "OBI Passwort"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Anmeldung fehlgeschlagen. Bitte überprüfe E-Mail und Passwort.",
+      "cannot_connect": "Verbindung zu den OBI-Servern konnte nicht hergestellt werden. Bitte später erneut versuchen.",
+      "invalid_ids": "Für die eingegebene Haushalts-/Sensor-ID konnten keine Daten gefunden werden."
+    },
+    "abort": {
+      "already_configured": "Diese Bridge/dieser Sensor ist bereits konfiguriert.",
+      "reauth_successful": "Die erneute Anmeldung war erfolgreich.",
+      "reconfigure_successful": "Die OBI-Zugangsdaten wurden erfolgreich aktualisiert."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "OBI Energy Optionen",
+        "description": "Konfiguriere, wie oft Daten abgerufen und Zugangsdaten erneuert werden.",
+        "data": {
+          "scan_interval": "Abfrageintervall Messwerte (Sekunden)",
+          "login_refresh_interval": "Login-Refresh-Intervall (Sekunden)",
+          "historical_duration": "Zeitraum Messwerte (ISO 8601, z. B. PT6H)",
+          "debug": "Debug-Logging aktivieren",
+          "hh_id": "Haushalts-ID (HH_ID) überschreiben",
+          "mid_id": "Sensor-ID (MID_ID) überschreiben"
+        }
+      }
+    }
+  }
+}

--- a/custom_components/obi_energy/translations/en.json
+++ b/custom_components/obi_energy/translations/en.json
@@ -1,0 +1,70 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to OBI Energy",
+        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token.",
+        "data": {
+          "email": "OBI email",
+          "password": "OBI password"
+        }
+      },
+      "select_bridge": {
+        "title": "Select bridge and sensor",
+        "description": "Multiple OBI bridges/sensors were found on your account. Choose the one to monitor.",
+        "data": {
+          "bridge": "Bridge / sensor"
+        }
+      },
+      "manual": {
+        "title": "Enter bridge and sensor IDs manually",
+        "description": "The bridge list could not be retrieved automatically. Enter the household ID (HH_ID) and sensor ID (MID_ID) manually.",
+        "data": {
+          "hh_id": "Household ID (HH_ID)",
+          "mid_id": "Sensor ID (MID_ID)"
+        }
+      },
+      "reauth_confirm": {
+        "title": "Re-authenticate with OBI",
+        "description": "The stored OBI password for {email} no longer works. Enter the current password to continue.",
+        "data": {
+          "password": "OBI password"
+        }
+      },
+      "reconfigure_confirm": {
+        "title": "Update OBI credentials",
+        "description": "Update the OBI email and/or password used by this integration.",
+        "data": {
+          "email": "OBI email",
+          "password": "OBI password"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Login failed. Please check your OBI email and password.",
+      "cannot_connect": "Could not connect to the OBI servers. Please try again later.",
+      "invalid_ids": "No data could be found for the entered household/sensor ID."
+    },
+    "abort": {
+      "already_configured": "This bridge/sensor is already configured.",
+      "reauth_successful": "Re-authentication was successful.",
+      "reconfigure_successful": "The OBI credentials were updated successfully."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "OBI Energy options",
+        "description": "Configure how often data is fetched and refreshed.",
+        "data": {
+          "scan_interval": "Measurement scan interval (seconds)",
+          "login_refresh_interval": "Login refresh interval (seconds)",
+          "historical_duration": "Historical data duration (ISO 8601, e.g. PT6H)",
+          "debug": "Enable debug logging",
+          "hh_id": "Override household ID (HH_ID)",
+          "mid_id": "Override sensor ID (MID_ID)"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Config-flow based integration for the OBI/heyOBI Energy Tracking API: login + bridge discovery (auto or manual HH_ID/MID_ID), a DataUpdateCoordinator for polling, and sensor/binary_sensor entities for consumption, feed-in, battery, connectivity and diagnostics. Credentials live only in the config entry; the JWT is kept in memory only and never logged or exposed. Includes reauth/reconfigure flows, an options flow for scan/login-refresh intervals and debug logging, diagnostics support, and German/English translations.


Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c