### PR TITLE
Improve error diagnostics for OBI config flow and API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,18 @@ Dashboard — not the Wh sensors or the net sensor.
 - Use the **manual `HH_ID` / `MID_ID` override** in the integration options
   to keep the integration running with known IDs.
 
+### "Verbindung zu den OBI-Servern konnte nicht hergestellt werden" / `cannot_connect`
+
+This generic message is shown in the UI for any network-level failure. The
+Home Assistant log always has the real cause at `ERROR` level, logged from
+`custom_components.obi_energy.api` and `custom_components.obi_energy.config_flow`
+— check **Settings → System → Logs** (or `home-assistant.log`) right after
+the failed attempt. It will tell you whether the request failed due to DNS
+resolution, an SSL/TLS error, a timeout, or a specific HTTP status code
+(401/403/404/500/...), plus a truncated (max 300 characters) response body
+for HTTP errors — enough to diagnose the problem without exposing your
+token or password.
+
 ### Entities show "unavailable"
 
 This is expected when the API returns no data for that measurement (rather
@@ -161,6 +173,8 @@ integration options) for the underlying cause once it recovers.
 ## Security note
 
 Never post your JWT, email, or password in GitHub issues, logs, or
-screenshots when reporting problems. If you enable debug logging and share
-logs, review them first — credentials and tokens are deliberately excluded
-from all log output, but request/response bodies are not logged by design.
+screenshots when reporting problems. Credentials and tokens are deliberately
+excluded from all log output. On HTTP errors, the integration does log the
+HTTP status code and up to 300 characters of the response body to help with
+debugging — review logs before sharing them, in case OBI's error responses
+ever echo back unexpected data.

--- a/custom_components/obi_energy/api.py
+++ b/custom_components/obi_energy/api.py
@@ -5,12 +5,12 @@ never logged, never persisted, and never exposed to entities or attributes.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from aiohttp import ClientError, ClientResponseError, ClientSession
-from aiohttp.client_exceptions import ClientConnectorError
+import aiohttp
 
 from .const import (
     ACCEPT_BRIDGES,
@@ -19,6 +19,7 @@ from .const import (
     API_KEY,
     BRIDGES_URL,
     HISTORICAL_DATA_URL_TEMPLATE,
+    LOGIN_COOKIE,
     LOGIN_URL,
     USER_AGENT,
 )
@@ -26,6 +27,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 _REQUEST_TIMEOUT = 30
+_MAX_LOG_BODY_CHARS = 300
 
 
 class ObiApiError(Exception):
@@ -44,12 +46,38 @@ class ObiNotFoundError(ObiApiError):
     """Raised when a resource (e.g. /bridges) returns 404."""
 
 
+def _truncate(text: str | None) -> str:
+    """Truncate a response body to a safe length for logging."""
+    if not text:
+        return "<empty body>"
+    text = text.strip()
+    if len(text) > _MAX_LOG_BODY_CHARS:
+        return text[:_MAX_LOG_BODY_CHARS] + "... [truncated]"
+    return text
+
+
+async def _safe_text(resp: aiohttp.ClientResponse) -> str:
+    """Best-effort read of a response body for logging. Never raises."""
+    try:
+        return await resp.text()
+    except (aiohttp.ClientError, UnicodeDecodeError):
+        return "<could not read body>"
+
+
+async def _log_http_error(resp: aiohttp.ClientResponse, context: str) -> None:
+    """Log the HTTP status and a truncated body. Never logs tokens/passwords."""
+    body = await _safe_text(resp)
+    _LOGGER.error(
+        "%s failed with HTTP %s: %s", context, resp.status, _truncate(body)
+    )
+
+
 class ObiApiClient:
     """Thin async client for the OBI Energy Tracking API."""
 
     def __init__(
         self,
-        session: ClientSession,
+        session: aiohttp.ClientSession,
         email: str,
         password: str,
         login_refresh_interval: int,
@@ -91,7 +119,10 @@ class ObiApiClient:
             "user-agent": USER_AGENT,
             "accept-language": ACCEPT_LANGUAGE,
             "accept-encoding": "identity",
+            "cookie": LOGIN_COOKIE,
         }
+        _LOGGER.debug("Logging in to OBI (%s)", LOGIN_URL)
+
         try:
             async with self._session.post(
                 LOGIN_URL,
@@ -100,25 +131,54 @@ class ObiApiClient:
                 timeout=_REQUEST_TIMEOUT,
             ) as resp:
                 if resp.status in (401, 403):
-                    raise ObiAuthError("Login failed: invalid credentials")
-                resp.raise_for_status()
-                data = await resp.json(content_type=None)
-        except ClientResponseError as err:
-            if err.status in (401, 403):
-                raise ObiAuthError("Login failed: invalid credentials") from err
+                    await _log_http_error(resp, "OBI login")
+                    raise ObiAuthError(
+                        f"Login failed with HTTP {resp.status}: invalid credentials"
+                    )
+                if resp.status >= 400:
+                    await _log_http_error(resp, "OBI login")
+                    raise ObiConnectionError(
+                        f"Login request failed with HTTP {resp.status}"
+                    )
+                try:
+                    data = await resp.json(content_type=None)
+                except ValueError as err:
+                    text = await _safe_text(resp)
+                    _LOGGER.error(
+                        "OBI login returned invalid JSON (HTTP %s): %s",
+                        resp.status,
+                        _truncate(text),
+                    )
+                    raise ObiConnectionError(
+                        "Received invalid response from OBI login"
+                    ) from err
+        except aiohttp.ClientConnectorDNSError as err:
+            _LOGGER.error("DNS resolution failed while logging in to OBI: %s", err)
             raise ObiConnectionError(
-                f"Login request failed with HTTP {err.status}"
+                "DNS resolution failed for the OBI login endpoint"
             ) from err
-        except ClientConnectorError as err:
-            raise ObiConnectionError("Could not connect to OBI login endpoint") from err
-        except ClientError as err:
+        except aiohttp.ClientSSLError as err:
+            _LOGGER.error("SSL/TLS error while logging in to OBI: %s", err)
+            raise ObiConnectionError(
+                "SSL/TLS error while connecting to the OBI login endpoint"
+            ) from err
+        except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as err:
+            _LOGGER.error("Timeout while logging in to OBI: %s", err)
+            raise ObiConnectionError(
+                "Timeout while connecting to the OBI login endpoint"
+            ) from err
+        except aiohttp.ClientConnectorError as err:
+            _LOGGER.error("Could not connect to the OBI login endpoint: %s", err)
+            raise ObiConnectionError(
+                "Could not connect to the OBI login endpoint"
+            ) from err
+        except aiohttp.ClientError as err:
+            _LOGGER.error("Network error while logging in to OBI: %s", err)
             raise ObiConnectionError("Network error during OBI login") from err
-        except ValueError as err:
-            # JSON decoding failed
-            raise ObiConnectionError("Received invalid response from OBI login") from err
 
         token = data.get("token") if isinstance(data, dict) else None
         if not token:
+            _LOGGER.error("OBI login response did not contain a token")
             raise ObiAuthError("Login response did not contain a token")
 
         self._token = token
@@ -153,25 +213,49 @@ class ObiApiClient:
                     if resp.status == 401:
                         if attempt == 0:
                             _LOGGER.debug(
-                                "OBI API returned 401, refreshing token and retrying"
+                                "OBI API returned 401 for %s, refreshing token and retrying",
+                                url,
                             )
                             await self.async_login()
                             continue
+                        await _log_http_error(resp, f"OBI request to {url}")
                         raise ObiAuthError("Not authorized after refreshing token")
                     if resp.status == 404:
+                        _LOGGER.warning("OBI resource not found (HTTP 404): %s", url)
                         raise ObiNotFoundError(f"Resource not found: {url}")
-                    resp.raise_for_status()
-                    return await resp.json(content_type=None)
-            except ClientResponseError as err:
-                raise ObiConnectionError(
-                    f"Request to {url} failed with HTTP {err.status}"
-                ) from err
-            except ClientConnectorError as err:
+                    if resp.status >= 400:
+                        await _log_http_error(resp, f"OBI request to {url}")
+                        raise ObiConnectionError(
+                            f"Request to {url} failed with HTTP {resp.status}"
+                        )
+                    try:
+                        return await resp.json(content_type=None)
+                    except ValueError as err:
+                        text = await _safe_text(resp)
+                        _LOGGER.error(
+                            "OBI response for %s was not valid JSON (HTTP %s): %s",
+                            url,
+                            resp.status,
+                            _truncate(text),
+                        )
+                        raise ObiConnectionError(
+                            f"Received invalid response from {url}"
+                        ) from err
+            except aiohttp.ClientConnectorDNSError as err:
+                _LOGGER.error("DNS resolution failed requesting %s: %s", url, err)
+                raise ObiConnectionError(f"DNS resolution failed for {url}") from err
+            except aiohttp.ClientSSLError as err:
+                _LOGGER.error("SSL/TLS error requesting %s: %s", url, err)
+                raise ObiConnectionError(f"SSL/TLS error requesting {url}") from err
+            except (asyncio.TimeoutError, aiohttp.ServerTimeoutError) as err:
+                _LOGGER.error("Timeout requesting %s: %s", url, err)
+                raise ObiConnectionError(f"Timeout requesting {url}") from err
+            except aiohttp.ClientConnectorError as err:
+                _LOGGER.error("Could not connect to %s: %s", url, err)
                 raise ObiConnectionError(f"Could not connect to {url}") from err
-            except ClientError as err:
+            except aiohttp.ClientError as err:
+                _LOGGER.error("Network error requesting %s: %s", url, err)
                 raise ObiConnectionError(f"Network error requesting {url}") from err
-            except ValueError as err:
-                raise ObiConnectionError(f"Received invalid response from {url}") from err
 
         raise ObiAuthError("Not authorized after refreshing token")
 
@@ -179,6 +263,9 @@ class ObiApiClient:
         """Return the list of bridges (households) with their sensors."""
         data = await self._authenticated_get(BRIDGES_URL, accept=ACCEPT_BRIDGES)
         if not isinstance(data, list):
+            _LOGGER.error(
+                "Unexpected response type for /bridges: %s", type(data).__name__
+            )
             raise ObiConnectionError("Unexpected response format for /bridges")
         return data
 
@@ -195,5 +282,8 @@ class ObiApiClient:
         }
         data = await self._authenticated_get(url, accept=ACCEPT_HISTORICAL, params=params)
         if not isinstance(data, list):
+            _LOGGER.error(
+                "Unexpected response type for historical data: %s", type(data).__name__
+            )
             raise ObiConnectionError("Unexpected response format for historical data")
         return data

--- a/custom_components/obi_energy/config_flow.py
+++ b/custom_components/obi_energy/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for the OBI Energy integration."""
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 import voluptuous as vol
@@ -23,6 +24,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -87,17 +90,25 @@ class ObiEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
             try:
                 await client.async_login()
-            except ObiAuthError:
+            except ObiAuthError as err:
+                _LOGGER.warning("OBI login rejected during config flow: %s", err)
                 errors["base"] = "invalid_auth"
             except ObiConnectionError:
+                _LOGGER.exception("OBI connection failed during config flow (login)")
                 errors["base"] = "cannot_connect"
             else:
                 self._client = client
                 try:
                     bridges = await client.async_get_bridges()
-                except ObiNotFoundError:
+                except ObiNotFoundError as err:
+                    _LOGGER.info(
+                        "OBI /bridges not found, falling back to manual entry: %s", err
+                    )
                     return await self.async_step_manual()
                 except ObiConnectionError:
+                    _LOGGER.exception(
+                        "OBI connection failed during config flow (bridges)"
+                    )
                     errors["base"] = "cannot_connect"
                 else:
                     pairs = _flatten_bridges(bridges)
@@ -143,9 +154,15 @@ class ObiEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 await self._client.async_get_historical_data(
                     hh_id, mid_id, DEFAULT_HISTORICAL_DURATION
                 )
-            except ObiNotFoundError:
+            except ObiNotFoundError as err:
+                _LOGGER.warning(
+                    "OBI historical data not found for manual hh_id/mid_id: %s", err
+                )
                 errors["base"] = "invalid_ids"
             except ObiConnectionError:
+                _LOGGER.exception(
+                    "OBI connection failed during config flow (manual validation)"
+                )
                 errors["base"] = "cannot_connect"
             else:
                 return await self._async_create_entry(hh_id, mid_id)
@@ -193,9 +210,11 @@ class ObiEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 await client.async_login()
-            except ObiAuthError:
+            except ObiAuthError as err:
+                _LOGGER.warning("OBI reauth login rejected: %s", err)
                 errors["base"] = "invalid_auth"
             except ObiConnectionError:
+                _LOGGER.exception("OBI connection failed during reauth confirm")
                 errors["base"] = "cannot_connect"
             else:
                 new_data = {**self._reauth_entry.data, CONF_PASSWORD: password}
@@ -237,9 +256,11 @@ class ObiEnergyConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
             try:
                 await client.async_login()
-            except ObiAuthError:
+            except ObiAuthError as err:
+                _LOGGER.warning("OBI reconfigure login rejected: %s", err)
                 errors["base"] = "invalid_auth"
             except ObiConnectionError:
+                _LOGGER.exception("OBI connection failed during reconfigure confirm")
                 errors["base"] = "cannot_connect"
             else:
                 new_data = {**entry.data, CONF_EMAIL: email, CONF_PASSWORD: password}

--- a/custom_components/obi_energy/const.py
+++ b/custom_components/obi_energy/const.py
@@ -25,6 +25,7 @@ HISTORICAL_DATA_URL_TEMPLATE = API_BASE_URL + "/historical-data/{hh_id}/{mid_id}
 API_KEY = "Rh57q3vtOPYTf6FtArVN1boy2AyEiIqaGEmnMks7"
 USER_AGENT = "heyOBI APP / iPhone17,2 / 4.9.1 / 560"
 ACCEPT_LANGUAGE = "de-DE,de;q=0.9"
+LOGIN_COOKIE = "obi_storeid=527"
 ACCEPT_BRIDGES = "application/vnd.obi.companion.energy-tracking.bridge.v1+json"
 ACCEPT_HISTORICAL = "application/vnd.obi.companion.energy-tracking.historical-record.v1+json"
 


### PR DESCRIPTION
The config flow only ever surfaced a generic "cannot_connect" error, leaving no trace in the Home Assistant log to explain why. Add a _LOGGER to config_flow.py and log the real exception (with traceback) at every ObiConnectionError/ObiAuthError/ObiNotFoundError site.

In api.py, classify aiohttp failures explicitly (DNS resolution, SSL/TLS, timeout, connection refused, HTTP status, JSON decoding) and log each case distinctly, including the HTTP status and up to 300 characters of the response body on HTTP errors. Tokens and passwords are never logged.

Also add the `cookie: obi_storeid=527` header to the login request to match the previously working YAML REST sensor configuration.


Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c