### PR TITLE
Add country field to OBI login payload to match real app request

### DIFF
--- a/custom_components/obi_energy/api.py
+++ b/custom_components/obi_energy/api.py
@@ -21,6 +21,7 @@ from .const import (
     BRIDGES_URL,
     HISTORICAL_DATA_URL_TEMPLATE,
     LOGIN_COOKIE,
+    LOGIN_COUNTRY,
     LOGIN_HOST,
     LOGIN_ORIGIN,
     LOGIN_REFERER,
@@ -131,7 +132,11 @@ class ObiApiClient:
         # content-type/content-length handling and can conflict with the
         # exact headers OBI (and the CloudFront in front of it) expect.
         payload = json.dumps(
-            {"email": self._email, "password": self._password},
+            {
+                "password": self._password,
+                "country": LOGIN_COUNTRY,
+                "email": self._email,
+            },
             separators=(",", ":"),
         )
         payload_bytes = payload.encode("utf-8")

--- a/custom_components/obi_energy/const.py
+++ b/custom_components/obi_energy/const.py
@@ -29,6 +29,7 @@ LOGIN_COOKIE = "obi_storeid=527"
 LOGIN_HOST = "www.obi.de"
 LOGIN_ORIGIN = "https://www.obi.de"
 LOGIN_REFERER = "https://www.obi.de/"
+LOGIN_COUNTRY = "de"
 ACCEPT_BRIDGES = "application/vnd.obi.companion.energy-tracking.bridge.v1+json"
 ACCEPT_HISTORICAL = "application/vnd.obi.companion.energy-tracking.historical-record.v1+json"
 


### PR DESCRIPTION
A mitmproxy capture of the actual heyOBI app login request showed the body is {password, country, email} rather than just {email, password}. Add the missing "country": "de" field (in the same field order as the capture) so the request matches the real app 1:1, still sent via data= as compact JSON bytes.


Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c