### PR TITLE
Prepare v0.1.0 release: HACS packaging, device info, entity translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# Changelog
+
+All notable changes to the OBI Energy integration are documented in this file.
+
+## [0.1.0] - 2026-07-01
+
+First tagged release. The integration is fully config-flow based (no YAML),
+logs into the OBI/heyOBI Energy Tracking API, discovers the bridge/sensor,
+and exposes native Home Assistant entities for consumption, feed-in, battery,
+connectivity and diagnostics.
+
+### Added
+
+- Config flow: email/password entry, automatic bridge/sensor discovery with
+  a picker for multiple bridges, and a manual `HH_ID`/`MID_ID` fallback when
+  `/bridges` is unavailable.
+- Reauth flow (triggered automatically on authentication failure) and a
+  reconfigure flow to update credentials later.
+- Options flow: measurement scan interval, login refresh interval,
+  historical data duration, debug logging toggle, and manual `HH_ID`/`MID_ID`
+  overrides.
+- `DataUpdateCoordinator`-based polling with sensors for:
+  `sensor.obi_energy`, `sensor.obi_energy_kwh`, `sensor.obi_negative_energy`,
+  `sensor.obi_einspeisung_kwh`, `sensor.obi_netto_energy_kwh`,
+  `sensor.obi_bridge_battery`, `sensor.obi_bridge_connection_strength`,
+  `sensor.obi_last_record_received`, and `binary_sensor.obi_bridge_online`.
+- Diagnostics support (redacts email/password; the session token is never
+  persisted, logged, or exposed anywhere).
+- German and English translations for the config flow, options flow, and
+  entity names.
+- `hacs.json` for HACS custom-repository installation.
+
+### Fixed
+
+- Login now sends the exact request shape confirmed via a mitmproxy capture
+  of the real heyOBI app: a compact JSON body (`{"password", "country":
+  "de", "email"}`, no whitespace) sent as raw bytes via `data=` with an
+  explicit `Content-Length`, plus the `Host`/`Origin`/`Referer`/`Cookie`
+  headers the app sends. Earlier attempts using aiohttp's `json=` shortcut
+  were rejected by CloudFront in front of OBI's login endpoint.
+- Entities become `unavailable` (instead of reporting `0`) when login fails,
+  `/bridges` can't be retrieved, or historical data is empty/invalid, so
+  Home Assistant's Energy Dashboard statistics never see a false reading.
+- Config flow and API client now log the real failure reason (DNS, SSL,
+  timeout, HTTP status with response headers/truncated body, JSON decode
+  errors) instead of a generic "cannot connect", without ever logging
+  tokens, passwords, or full request bodies.
+- Device info is now consistent across all entities (`manufacturer: "OBI"`,
+  `model: "heyOBI Energy Tracking"`, device name `"OBI Energy"`), and entity
+  names use `translation_key` so they render correctly per language instead
+  of duplicating the device name.

--- a/README.md
+++ b/README.md
@@ -64,10 +64,16 @@ reporting `0`, so your Energy Dashboard statistics stay accurate.
 
 ### HACS (custom repository)
 
-1. In HACS, add this repository as a custom repository (category:
-   Integration).
-2. Install "OBI Energy".
-3. Restart Home Assistant.
+This integration is not (yet) in the default HACS store, so it needs to be
+added as a **custom repository**:
+
+1. Open **HACS → Integrations** in Home Assistant.
+2. Click the **⋮** (three-dot) menu in the top right corner and choose
+   **Custom repositories**.
+3. Add this repository's URL (`https://github.com/karo-x/obi_energy`) and
+   select category **Integration**, then **Add**.
+4. Find **OBI Energy** in HACS and click **Download**.
+5. Restart Home Assistant.
 
 ### Manual
 
@@ -169,6 +175,21 @@ This is expected when the API returns no data for that measurement (rather
 than showing a misleading `0`, which would corrupt Energy Dashboard
 statistics). Check Home Assistant logs (enable debug logging in the
 integration options) for the underlying cause once it recovers.
+
+## Icon & branding
+
+This integration does **not** bundle an OBI/heyOBI logo — trademark and
+usage rights for OBI's branding are unclear for a community project, so no
+`icon.png`/`logo.png` is included. Entities instead use Home Assistant's
+built-in Material Design Icons (e.g. `mdi:transmission-tower` for the bridge
+connection-strength sensor); most other entities get a sensible default icon
+from their `device_class` (energy, battery, connectivity, timestamp). In the
+integrations list, Home Assistant/HACS will show a generic placeholder icon
+instead of a brand logo — this is expected and intentional.
+
+## Release notes
+
+See [CHANGELOG.md](CHANGELOG.md) for the version history.
 
 ## Security note
 

--- a/custom_components/obi_energy/binary_sensor.py
+++ b/custom_components/obi_energy/binary_sensor.py
@@ -43,14 +43,17 @@ class ObiBridgeOnlineBinarySensor(
         super().__init__(coordinator)
         self.entity_description = BinarySensorEntityDescription(
             key="bridge_online",
-            name="OBI Bridge Online",
+            translation_key="bridge_online",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
             entity_category=EntityCategory.DIAGNOSTIC,
         )
         self._attr_unique_id = f"{entry.entry_id}_bridge_online"
+        # Pin the entity_id to binary_sensor.obi_bridge_online, matching the
+        # documented name regardless of the translated entity name.
+        self._attr_suggested_object_id = "obi_bridge_online"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{coordinator.hh_id}_{coordinator.mid_id}")},
-            name="OBI Energy Bridge",
+            name="OBI Energy",
             manufacturer="OBI",
             model="heyOBI Energy Tracking",
         )

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/karo-x/obi_energy/issues",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "0.1.0"
 }

--- a/custom_components/obi_energy/sensor.py
+++ b/custom_components/obi_energy/sensor.py
@@ -62,9 +62,12 @@ class ObiEnergyBaseEntity(CoordinatorEntity[ObiEnergyCoordinator], SensorEntity)
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{entry.entry_id}_{description.key}"
+        # Pin the entity_id (e.g. sensor.obi_energy) so it stays stable and
+        # matches the documented names regardless of the translated name.
+        self._attr_suggested_object_id = f"obi_{description.key}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{coordinator.hh_id}_{coordinator.mid_id}")},
-            name="OBI Energy Bridge",
+            name="OBI Energy",
             manufacturer="OBI",
             model="heyOBI Energy Tracking",
         )
@@ -80,7 +83,7 @@ class ObiEnergySensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="energy",
-                name="OBI Energy",
+                translation_key="energy",
                 native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY,
                 state_class=SensorStateClass.TOTAL_INCREASING,
@@ -109,7 +112,7 @@ class ObiEnergyKwhSensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="energy_kwh",
-                name="OBI Energy kWh",
+                translation_key="energy_kwh",
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY,
                 state_class=SensorStateClass.TOTAL_INCREASING,
@@ -139,7 +142,7 @@ class ObiNegativeEnergySensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="negative_energy",
-                name="OBI Negative Energy",
+                translation_key="negative_energy",
                 native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY,
                 state_class=SensorStateClass.TOTAL_INCREASING,
@@ -168,7 +171,7 @@ class ObiEinspeisungKwhSensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="einspeisung_kwh",
-                name="OBI Einspeisung kWh",
+                translation_key="einspeisung_kwh",
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY,
                 state_class=SensorStateClass.TOTAL_INCREASING,
@@ -198,7 +201,7 @@ class ObiNettoEnergyKwhSensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="netto_energy_kwh",
-                name="OBI Netto Energy kWh",
+                translation_key="netto_energy_kwh",
                 native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
                 device_class=SensorDeviceClass.ENERGY,
                 state_class=SensorStateClass.TOTAL,
@@ -235,7 +238,7 @@ class ObiBridgeBatterySensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="bridge_battery",
-                name="OBI Bridge Battery",
+                translation_key="bridge_battery",
                 native_unit_of_measurement=PERCENTAGE,
                 device_class=SensorDeviceClass.BATTERY,
                 entity_category=EntityCategory.DIAGNOSTIC,
@@ -264,7 +267,8 @@ class ObiBridgeConnectionStrengthSensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="bridge_connection_strength",
-                name="OBI Bridge Connection Strength",
+                translation_key="bridge_connection_strength",
+                icon="mdi:transmission-tower",
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),
         )
@@ -306,7 +310,7 @@ class ObiLastRecordReceivedSensor(ObiEnergyBaseEntity):
             entry,
             SensorEntityDescription(
                 key="last_record_received",
-                name="OBI Last Record Received",
+                translation_key="last_record_received",
                 device_class=SensorDeviceClass.TIMESTAMP,
                 entity_category=EntityCategory.DIAGNOSTIC,
             ),

--- a/custom_components/obi_energy/strings.json
+++ b/custom_components/obi_energy/strings.json
@@ -66,5 +66,38 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Consumption"
+      },
+      "energy_kwh": {
+        "name": "Consumption (kWh)"
+      },
+      "negative_energy": {
+        "name": "Feed-in"
+      },
+      "einspeisung_kwh": {
+        "name": "Feed-in (kWh)"
+      },
+      "netto_energy_kwh": {
+        "name": "Net (kWh)"
+      },
+      "bridge_battery": {
+        "name": "Bridge battery"
+      },
+      "bridge_connection_strength": {
+        "name": "Bridge connection strength"
+      },
+      "last_record_received": {
+        "name": "Last record received"
+      }
+    },
+    "binary_sensor": {
+      "bridge_online": {
+        "name": "Bridge online"
+      }
+    }
   }
 }

--- a/custom_components/obi_energy/translations/de.json
+++ b/custom_components/obi_energy/translations/de.json
@@ -66,5 +66,38 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Verbrauch"
+      },
+      "energy_kwh": {
+        "name": "Verbrauch (kWh)"
+      },
+      "negative_energy": {
+        "name": "Einspeisung"
+      },
+      "einspeisung_kwh": {
+        "name": "Einspeisung (kWh)"
+      },
+      "netto_energy_kwh": {
+        "name": "Netto (kWh)"
+      },
+      "bridge_battery": {
+        "name": "Bridge-Batterie"
+      },
+      "bridge_connection_strength": {
+        "name": "Bridge-Verbindungsstärke"
+      },
+      "last_record_received": {
+        "name": "Letzter Messwert empfangen"
+      }
+    },
+    "binary_sensor": {
+      "bridge_online": {
+        "name": "Bridge online"
+      }
+    }
   }
 }

--- a/custom_components/obi_energy/translations/en.json
+++ b/custom_components/obi_energy/translations/en.json
@@ -66,5 +66,38 @@
         }
       }
     }
+  },
+  "entity": {
+    "sensor": {
+      "energy": {
+        "name": "Consumption"
+      },
+      "energy_kwh": {
+        "name": "Consumption (kWh)"
+      },
+      "negative_energy": {
+        "name": "Feed-in"
+      },
+      "einspeisung_kwh": {
+        "name": "Feed-in (kWh)"
+      },
+      "netto_energy_kwh": {
+        "name": "Net (kWh)"
+      },
+      "bridge_battery": {
+        "name": "Bridge battery"
+      },
+      "bridge_connection_strength": {
+        "name": "Bridge connection strength"
+      },
+      "last_record_received": {
+        "name": "Last record received"
+      }
+    },
+    "binary_sensor": {
+      "bridge_online": {
+        "name": "Bridge online"
+      }
+    }
   }
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,5 @@
+{
+  "name": "OBI Energy",
+  "render_readme": true,
+  "homeassistant": "2024.1.0"
+}


### PR DESCRIPTION
- Bump manifest.json version to 0.1.0 (domain, config_flow and iot_class were already correct).
- Add hacs.json for HACS custom-repository installation.
- Add CHANGELOG.md documenting the history up to this release.
- Fix device info: all entities now consistently report manufacturer "OBI", model "heyOBI Energy Tracking", and device name "OBI Energy" (previously "OBI Energy Bridge", which duplicated awkwardly with entity names).
- Switch entities from hardcoded English names to translation_key + strings.json/translations, with matching German/English entity names. Pin each entity's suggested_object_id (e.g. "obi_energy", "obi_bridge_battery") so entity_ids stay exactly as originally specified regardless of the translated display name.
- Add an mdi:transmission-tower icon to the connection-strength sensor, which has no device_class-derived default icon, instead of bundling any OBI-branded logo/icon asset.
- README: explicit step-by-step HACS custom-repository instructions, a note on why no OBI logo is bundled, and a link to CHANGELOG.md.

Availability handling (unavailable instead of 0 on login/bridges/ historical-data failure) and token handling (in-memory only, 401 retry-once, proactive refresh, never logged) were already correct and verified unchanged in this pass.


Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c