### PR TITLE
Add cache-busting headers and debug logging for stale measurements

### DIFF
--- a/custom_components/obi_energy/api.py
+++ b/custom_components/obi_energy/api.py
@@ -225,6 +225,12 @@ class ObiApiClient:
             "Accept": accept,
             "accept-language": ACCEPT_LANGUAGE,
             "user-agent": USER_AGENT,
+            # OBI's API is fronted by CloudFront. Ask it (and any
+            # intermediate cache) to not serve a stale cached response for
+            # historical-data polls, which otherwise can appear to "stop
+            # updating" even though fresh readings exist upstream.
+            "cache-control": "no-cache",
+            "pragma": "no-cache",
         }
 
     async def _ensure_logged_in(self) -> None:

--- a/custom_components/obi_energy/coordinator.py
+++ b/custom_components/obi_energy/coordinator.py
@@ -102,6 +102,16 @@ class ObiEnergyCoordinator(DataUpdateCoordinator[ObiEnergyData]):
         energy = _latest_measurement(historical, MEASURE_ENERGY)
         negative_energy = _latest_measurement(historical, MEASURE_NEGATIVE_ENERGY)
 
+        _LOGGER.debug(
+            "Historical data poll: %d record(s) returned; latest energy=%s "
+            "(value=%s); latest negative_energy=%s (value=%s)",
+            len(historical),
+            energy.get("timestamp") if energy else None,
+            energy.get("value") if energy else None,
+            negative_energy.get("timestamp") if negative_energy else None,
+            negative_energy.get("value") if negative_energy else None,
+        )
+
         return ObiEnergyData(
             sensor_info=sensor_info,
             energy=energy,


### PR DESCRIPTION
Issue #10: energy/negative_energy measurements stop updating even though the OBI app itself shows fresh readings and the bridge's lastRecordReceivedAt (from /bridges) keeps advancing. Since OBI's API sits behind CloudFront (already confirmed to affect the login endpoint), the most likely explanation is an intermediate cache serving a stale /historical-data response - our default 60s scan interval polls that endpoint far more often than the OBI app itself likely does.

- Send Cache-Control: no-cache and Pragma: no-cache on every authenticated GET (bridges + historical-data), in case CloudFront or the origin honors them to bypass a cached response.
- Log the historical-data poll result (record count, latest energy/ negative_energy timestamp and value) at debug level, so a user who enables debug logging can see directly whether the API itself is returning stale timestamps (OBI-side) or whether parsing picks the wrong record (our bug) if the cache-control fix alone doesn't resolve it.


Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c