### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v0.1.1
+
+Fixes #10 (energy/negative_energy measurements stop updating even though
+the OBI app shows fresh readings):
+
+- `/historical-data` now sends a single ISO 8601 `<start>/<duration>`
+  interval as one `duration` parameter, instead of separate `end=`/
+  `duration=` query parameters - matching the request shape confirmed to
+  work in another OBI HACS integration. The previous two-parameter form
+  may not have been parsed correctly by OBI's backend.
+- Added `Cache-Control: no-cache` / `Pragma: no-cache` headers on every
+  authenticated request, in case CloudFront (which fronts OBI's API) was
+  serving a stale cached response.
+- Added debug-level logging of each historical-data poll (record count,
+  latest energy/negative_energy timestamp and value) to help diagnose any
+  remaining staleness directly from the Home Assistant log.
+
 ## v0.1.0
 
 Initial working release:

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Karo-X/obi_energy/issues",
   "requirements": [],
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
## Summary

- Bump `manifest.json` version from `0.1.0` to `0.1.1`, since the previous 0.1.0 prep never got tagged/released before the issue #10 fix (historical-data duration format) and the cache-control header fix landed.
- Add a `CHANGELOG.md` entry for 0.1.1 documenting the issue #10 fix.

Since real users (e.g. the issue #10 reporter) already have this integration installed, this gives the fix its own distinguishable version instead of folding it into a 0.1.0 that would already contain post-hoc bugfixes.

## Test plan

- [x] `manifest.json` valid JSON, `version: "0.1.1"`
- [x] HACS Action / hassfest expected to pass (no functional code changes, only manifest version + changelog)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_