### PR TITLE
Mention Configure options in the setup description

### DIFF
--- a/custom_components/obi_energy/strings.json
+++ b/custom_components/obi_energy/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to OBI Energy",
-        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token.",
+        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token. After setup, you can use \"Configure\" on the integration to adjust the scan interval and historical data duration.",
         "data": {
           "email": "OBI email",
           "password": "OBI password"

--- a/custom_components/obi_energy/translations/de.json
+++ b/custom_components/obi_energy/translations/de.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Mit OBI Energy verbinden",
-        "description": "Gib die E-Mail-Adresse und das Passwort ein, die du auch für die heyOBI-App verwendest. Deine Zugangsdaten werden sicher im Config Entry von Home Assistant gespeichert, niemals in YAML, und nur verwendet, um ein Sitzungs-Token zu erhalten.",
+        "description": "Gib die E-Mail-Adresse und das Passwort ein, die du auch für die heyOBI-App verwendest. Deine Zugangsdaten werden sicher im Config Entry von Home Assistant gespeichert, niemals in YAML, und nur verwendet, um ein Sitzungs-Token zu erhalten. Nach dem Setup kannst du über \"Configure\" das Abfrageintervall und den Zeitraum der Messwerte anpassen.",
         "data": {
           "email": "OBI E-Mail",
           "password": "OBI Passwort"

--- a/custom_components/obi_energy/translations/en.json
+++ b/custom_components/obi_energy/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Connect to OBI Energy",
-        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token.",
+        "description": "Enter the email address and password you use for the heyOBI app. Your credentials are stored securely in Home Assistant's config entry storage, never in YAML, and are only used to obtain a session token. After setup, you can use \"Configure\" on the integration to adjust the scan interval and historical data duration.",
         "data": {
           "email": "OBI email",
           "password": "OBI password"


### PR DESCRIPTION
## Summary

- Add a one-line pointer in the config flow's initial (`user`) step description, in English and German: after setup, scan interval and historical data duration can be adjusted via "Configure" on the integration.

## Why

The setting was already adjustable via the Options flow, but nothing in the UI ever told new users it existed — several issue #10 commenters only discovered `historical_duration` because they asked directly. This is a documentation/discoverability fix, no behavior change.

## Test plan

- [x] `strings.json`, both translation files valid JSON

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c

---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_