### PR TITLE
Bump version to 0.2.0 for live tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## v0.2.0
+
+Adds optional live tracking (PR #13, contributed by @la-sina), plus a fix for
+stale `energy`/`negative_energy` readings that affects everyone.
+
+### Added
+
+- **Live tracking** (disabled by default, enable via the integration's
+  **Configure** options): opens a WebSocket connection to OBI's live-mode
+  endpoint and requests a fast (2-second) sensor upload interval, exposing
+  four new diagnostic entities — `sensor.obi_live_power`,
+  `sensor.obi_live_rssi`, `sensor.obi_live_battery`, and
+  `sensor.obi_live_last_message`. `sensor.obi_live_power` reports raw watts as
+  sent by OBI; the sign convention for consumption vs. feed-in is not yet
+  confirmed. Turning live tracking off (or unloading/reloading the
+  integration) restores the sensor's normal 300-second upload interval so the
+  physical device doesn't stay in fast-report mode.
+
+### Fixed
+
+- Historical polling for `energy`/`negative_energy` no longer stalls while
+  live tracking is active — the live-data listener previously nudged the
+  coordinator's regular refresh timer on every live message, which could
+  starve the normal historical-data poll when live updates arrived every
+  couple of seconds.
+- `_latest_measurement` now also recognizes a `time` field (in addition to
+  `timestamp`) on historical records, matching a response variant observed
+  from OBI's API.
+
 ## v0.1.2
 
 Reduces the default `historical_duration` from `PT6H` to `PT15M`.

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Karo-X/obi_energy/issues",
   "requirements": [],
-  "version": "0.1.2"
+  "version": "0.2.0"
 }


### PR DESCRIPTION
## Summary
- Bumps `manifest.json` version to `0.2.0` following the merge of #13 (live tracking, contributed by @la-sina)
- Adds a `CHANGELOG.md` entry documenting the new live-tracking feature and the accompanying fixes (historical-polling starvation during live updates, `time`/`timestamp` field fallback)

## Test plan
- [x] `hassfest` / HACS validation pass (same as on #13)
- [ ] Maintainer to publish a GitHub Release for `v0.2.0` after merging, so HACS shows the update


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_