### PR TITLE
[Beta] Add switch to toggle live tracking at runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased (beta)
+
+Adds `switch.obi_live_tracking` (fixes #19) to turn live tracking on/off at
+runtime — from an automation, script, or the dashboard — without reloading
+the integration. The **Enable live tracking** option now only controls the
+state live tracking starts in after a Home Assistant restart; the switch is
+what you'd wire up to e.g. disable live tracking during off-peak hours to
+save the sensor's battery, and re-enable it later.
+
+This is a new, less-tested addition — please try it out and report any
+issues before it's promoted to a regular release.
+
 ## v0.2.1
 
 Raises the default `scan_interval` from 60 to 300 seconds.

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Assistant energy tooling — and the Energy Dashboard — expects kWh.
 | `sensor.obi_live_rssi` | dBm | signal_strength | measurement |
 | `sensor.obi_live_battery` | % | battery | measurement |
 | `sensor.obi_live_last_message` | – | timestamp | – |
+| `switch.obi_live_tracking` | – | – | – (turns live tracking on/off at runtime) |
 | `sensor.obi_bridge_battery` | % | battery | – |
 | `binary_sensor.obi_bridge_online` | – | connectivity | – |
 | `sensor.obi_bridge_connection_strength` | – | – | – (text, e.g. `GOOD_CONNECTION`) |
@@ -129,13 +130,25 @@ After setup, click **Configure** on the integration to adjust:
   this small. Larger windows (e.g. `PT6H`) have been observed in practice to
   make OBI's API return older data instead of the latest reading, causing
   the energy sensors to appear stuck.
-- **Enable live tracking** (default: disabled) — turns the live WebSocket and
-  live-mode activation request on or off. Enabling requests OBI's 2-second
+- **Enable live tracking** (default: disabled) — the state live tracking
+  starts in when Home Assistant (re)starts. Enabling requests OBI's 2-second
   live upload interval; disabling closes the live stream and restores the
   normal 300-second upload interval.
 - **Debug logging**
 - **Manual `HH_ID` / `MID_ID` overrides** (useful if `/bridges` starts
   failing after setup)
+
+### Toggling live tracking at runtime (beta)
+
+**`switch.obi_live_tracking`** lets you turn live tracking on/off from an
+automation, script, or the dashboard, without reloading the integration or
+going through **Configure**. This is useful if you only want the higher
+battery/radio usage of live mode during certain hours (e.g. off-peak, when
+the base load is the only thing worth watching closely) and the normal
+5-minute polling the rest of the time. The **Enable live tracking** option
+only decides the starting state after a Home Assistant restart; the switch
+is the one to automate. This is a new, less-tested feature — feedback and
+bug reports are welcome.
 
 ### Changing your password
 

--- a/custom_components/obi_energy/__init__.py
+++ b/custom_components/obi_energy/__init__.py
@@ -27,7 +27,7 @@ from .coordinator import ObiEnergyCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR]
+PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SWITCH]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/obi_energy/coordinator.py
+++ b/custom_components/obi_energy/coordinator.py
@@ -113,6 +113,7 @@ class ObiEnergyCoordinator(DataUpdateCoordinator[ObiEnergyData]):
 
     async def async_start_live_updates(self) -> None:
         """Start listening for live power readings."""
+        self.live_enabled = True
         if self._live_task is not None and not self._live_task.done():
             return
         self._live_stop = asyncio.Event()
@@ -129,6 +130,7 @@ class ObiEnergyCoordinator(DataUpdateCoordinator[ObiEnergyData]):
 
     async def async_stop_live_updates(self) -> None:
         """Stop the live-data listener."""
+        self.live_enabled = False
         had_live_task = self._live_task is not None
         if self._live_stop is not None:
             self._live_stop.set()

--- a/custom_components/obi_energy/strings.json
+++ b/custom_components/obi_energy/strings.json
@@ -60,7 +60,7 @@
           "scan_interval": "Measurement scan interval (seconds)",
           "login_refresh_interval": "Login refresh interval (seconds)",
           "historical_duration": "Historical data duration (ISO 8601, e.g. PT15M)",
-          "live_enabled": "Enable live tracking",
+          "live_enabled": "Enable live tracking on startup (can be toggled at runtime with the \"Live tracking\" switch)",
           "debug": "Enable debug logging",
           "hh_id": "Override household ID (HH_ID)",
           "mid_id": "Override sensor ID (MID_ID)"
@@ -110,6 +110,11 @@
     "binary_sensor": {
       "bridge_online": {
         "name": "Bridge online"
+      }
+    },
+    "switch": {
+      "live_tracking": {
+        "name": "Live tracking"
       }
     }
   }

--- a/custom_components/obi_energy/switch.py
+++ b/custom_components/obi_energy/switch.py
@@ -1,0 +1,71 @@
+"""Switch platform for the OBI Energy integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import ObiEnergyCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the OBI Energy switch from a config entry."""
+    coordinator: ObiEnergyCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([ObiLiveTrackingSwitch(coordinator, entry)])
+
+
+class ObiLiveTrackingSwitch(CoordinatorEntity[ObiEnergyCoordinator], SwitchEntity):
+    """Switch to turn live tracking on/off at runtime.
+
+    This complements the "Enable live tracking" option (which only sets the
+    state used when Home Assistant starts): toggling this switch starts or
+    stops the live WebSocket immediately, without reloading the integration,
+    so it can be driven from automations/schedules.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: ObiEnergyCoordinator, entry: ConfigEntry) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator)
+        self.entity_description = SwitchEntityDescription(
+            key="live_tracking",
+            translation_key="live_tracking",
+            entity_category=EntityCategory.CONFIG,
+        )
+        self._attr_unique_id = f"{entry.entry_id}_live_tracking"
+        self._attr_suggested_object_id = "obi_live_tracking"
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{coordinator.hh_id}_{coordinator.mid_id}")},
+            name="OBI Energy Bridge",
+            manufacturer="OBI",
+            model="heyOBI Energy Tracking",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True while live tracking is enabled."""
+        return self.coordinator.live_enabled
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Start live tracking."""
+        await self.coordinator.async_start_live_updates()
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Stop live tracking."""
+        await self.coordinator.async_stop_live_updates()
+        self.async_write_ha_state()

--- a/custom_components/obi_energy/translations/de.json
+++ b/custom_components/obi_energy/translations/de.json
@@ -60,7 +60,7 @@
           "scan_interval": "Abfrageintervall Messwerte (Sekunden)",
           "login_refresh_interval": "Login-Refresh-Intervall (Sekunden)",
           "historical_duration": "Zeitraum Messwerte (ISO 8601, z. B. PT15M)",
-          "live_enabled": "Live-Tracking aktivieren",
+          "live_enabled": "Live-Tracking beim Start aktivieren (kann zur Laufzeit über den Schalter \"Live-Tracking\" umgeschaltet werden)",
           "debug": "Debug-Logging aktivieren",
           "hh_id": "Haushalts-ID (HH_ID) überschreiben",
           "mid_id": "Sensor-ID (MID_ID) überschreiben"
@@ -110,6 +110,11 @@
     "binary_sensor": {
       "bridge_online": {
         "name": "Bridge online"
+      }
+    },
+    "switch": {
+      "live_tracking": {
+        "name": "Live-Tracking"
       }
     }
   }

--- a/custom_components/obi_energy/translations/en.json
+++ b/custom_components/obi_energy/translations/en.json
@@ -60,7 +60,7 @@
           "scan_interval": "Measurement scan interval (seconds)",
           "login_refresh_interval": "Login refresh interval (seconds)",
           "historical_duration": "Historical data duration (ISO 8601, e.g. PT15M)",
-          "live_enabled": "Enable live tracking",
+          "live_enabled": "Enable live tracking on startup (can be toggled at runtime with the \"Live tracking\" switch)",
           "debug": "Enable debug logging",
           "hh_id": "Override household ID (HH_ID)",
           "mid_id": "Override sensor ID (MID_ID)"
@@ -110,6 +110,11 @@
     "binary_sensor": {
       "bridge_online": {
         "name": "Bridge online"
+      }
+    },
+    "switch": {
+      "live_tracking": {
+        "name": "Live tracking"
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes #19 — adds `switch.obi_live_tracking` so live tracking can be turned on/off at runtime (automation, script, dashboard) without reloading the integration.

- `switch.py`: new `ObiLiveTrackingSwitch` entity backed by the existing `coordinator.async_start_live_updates()` / `async_stop_live_updates()`.
- `coordinator.py`: `live_enabled` is now updated whenever live tracking is actually started/stopped, so it reflects the current runtime state rather than only the value chosen at setup.
- `__init__.py`: registers the new `Platform.SWITCH`.
- Options flow's **Enable live tracking** now only controls the state live tracking starts in after a Home Assistant restart; the switch is what you'd wire up to automate it (e.g. off-peak hours only).
- README + translations (en/de) updated accordingly.

This is intentionally marked **beta** in the CHANGELOG (no version bump yet) — would like it tested for a bit (e.g. by @niclas18, who requested this in #19) before cutting a regular release.

## Test plan
- [x] `python -m py_compile` on changed Python files
- [x] `strings.json`/`translations/*.json` validated as JSON
- [ ] Manual test in a running Home Assistant instance: toggle `switch.obi_live_tracking` on/off and confirm the live sensors start/stop updating and the sensor's upload interval is restored on off
- [ ] hassfest / HACS validation (CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_