### PR TITLE
Bump version to 0.3.0-beta.1 for the live-tracking switch beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## Unreleased (beta)
+## v0.3.0-beta.1
+
+**Beta pre-release** — published so it can be installed via HACS by enabling
+"Show beta versions" for this repository, without affecting users on the
+regular v0.2.1 release. Please try it out and report any issues in the
+GitHub issues before it's promoted to a regular release.
 
 Adds `switch.obi_live_tracking` (fixes #19) to turn live tracking on/off at
 runtime — from an automation, script, or the dashboard — without reloading
@@ -8,9 +13,6 @@ the integration. The **Enable live tracking** option now only controls the
 state live tracking starts in after a Home Assistant restart; the switch is
 what you'd wire up to e.g. disable live tracking during off-peak hours to
 save the sensor's battery, and re-enable it later.
-
-This is a new, less-tested addition — please try it out and report any
-issues before it's promoted to a regular release.
 
 ## v0.2.1
 

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Karo-X/obi_energy/issues",
   "requirements": [],
-  "version": "0.2.1"
+  "version": "0.3.0-beta.1"
 }


### PR DESCRIPTION
## Summary
- Bumps `manifest.json` version to `0.3.0-beta.1` so the live-tracking switch (#20) can be shipped as a GitHub pre-release
- Moves the CHANGELOG entry from "Unreleased (beta)" to a proper `v0.3.0-beta.1` section, noting it's a beta pre-release

## Test plan
- [x] `hassfest` / HACS validation should pass
- [x] Maintainer to publish a GitHub Release tagged `v0.3.0-beta.1` with **"Set as a pre-release"** checked, so it only shows up for users who enable "Show beta versions" in HACS


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_