### PR TITLE
Fix live_rssi/live_battery not becoming unavailable when stale (v0.3.0-beta.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.3.0-beta.2
+
+**Beta pre-release.**
+
+### Fixed
+
+- `sensor.obi_live_rssi` and `sensor.obi_live_battery` now correctly become
+  `unavailable` once live data goes stale (no message for 90+ seconds, e.g.
+  after live tracking is turned off via `switch.obi_live_tracking`), instead
+  of showing the last known value indefinitely. `sensor.obi_live_power`
+  already behaved this way; the other two live sensors were missed.
+
 ## v0.3.0-beta.1
 
 **Beta pre-release** — published so it can be installed via HACS by enabling

--- a/custom_components/obi_energy/manifest.json
+++ b/custom_components/obi_energy/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/Karo-X/obi_energy/issues",
   "requirements": [],
-  "version": "0.3.0-beta.1"
+  "version": "0.3.0-beta.2"
 }

--- a/custom_components/obi_energy/sensor.py
+++ b/custom_components/obi_energy/sensor.py
@@ -297,8 +297,9 @@ class ObiLiveRssiSensor(ObiEnergyBaseEntity):
 
     @property
     def available(self) -> bool:
-        """Return True once a live RSSI reading has arrived."""
-        return super().available and self.coordinator.data.live_rssi is not None
+        """Return True once a live RSSI reading has arrived and isn't stale."""
+        data = self.coordinator.data
+        return super().available and data.live_rssi is not None and not data.live_stale
 
     @property
     def native_value(self) -> int | None:
@@ -326,8 +327,11 @@ class ObiLiveBatterySensor(ObiEnergyBaseEntity):
 
     @property
     def available(self) -> bool:
-        """Return True once a live battery reading has arrived."""
-        return super().available and self.coordinator.data.live_battery is not None
+        """Return True once a live battery reading has arrived and isn't stale."""
+        data = self.coordinator.data
+        return (
+            super().available and data.live_battery is not None and not data.live_stale
+        )
 
     @property
     def native_value(self) -> int | None:


### PR DESCRIPTION
## Summary
Found while testing the v0.3.0-beta.1 switch: `sensor.obi_live_rssi` and `sensor.obi_live_battery` were missing the `live_stale` check that `sensor.obi_live_power` already had, so after live tracking stopped (or the WebSocket went quiet for 90+ seconds) they kept showing the last known value forever instead of becoming `unavailable`.

- `sensor.py`: `ObiLiveRssiSensor.available` / `ObiLiveBatterySensor.available` now also check `not data.live_stale`, matching `ObiLivePowerSensor`.
- Bumps version to `0.3.0-beta.2` and adds a CHANGELOG entry.

## Test plan
- [x] `python -m py_compile` on the changed file
- [ ] Manual test: turn off `switch.obi_live_tracking` (or wait 90s+ without a live message) and confirm `sensor.obi_live_rssi`/`sensor.obi_live_battery` go `unavailable`
- [ ] hassfest / HACS validation (CI)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EgdizTwwuvvTd2pTodK75c)_